### PR TITLE
Automatically create command when plugin is loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 ## Usage
 
 ```vim
-command! -range=% -nargs=1 Align lua require'align'.align(<f-args>)
-
 " In visual mode
-:'<,'>Align regex_pattern.*
+:'<,'>Align regex_pattern
 ```
 
 *Note:* If used in normal mode, the previous visual selection will be used.
@@ -29,7 +27,7 @@ var xxxxxx = 6
 Command:
 
 ```vim
-:'<,'>lua require('align').align('=')
+:'<,'>Align =
 ```
 
 Resulting text:
@@ -46,7 +44,7 @@ var xxxxxx = 6
 You can then operate on the same text again without highlighting it. For example:
 
 ```vim
-:lua require('align').align('x ')
+:Align x\ 
 ```
 
 Resulting in:

--- a/doc/align.txt
+++ b/doc/align.txt
@@ -22,8 +22,8 @@ COMMANDS                                                     *align-commands*
 	be aligned.
 
 :AlignLines {pattern}, {startline}, {endline}                    *AlignLines*
-        Aligns {pattern} from {startline} to {endline}. Indexing is
-        zero-indexed, end-exclusive. Escape whitespace with backslash.
+        Aligns {pattern} from {startline} to {endline}. Range is inclusive,
+	by line number. Escape whitespace with backslash.
 
 EXAMPLES                                                     *align-examples*
 ===========================================================================
@@ -60,9 +60,9 @@ EXAMPLES                                                     *align-examples*
 >
 	1  var      x      = 1
 	2  var x    x     = 2
-	3  var xx   x    = 3
-	4  var xxx  x    = 4
-	5  var xxxx x    = 5
+	3  var xx   x     = 3
+	4  var xxx  x     = 4
+	5  var xxxx x     = 5
 	6  var xxxxxx = 6
 <
 

--- a/doc/align.txt
+++ b/doc/align.txt
@@ -3,26 +3,67 @@
 Author:  Adam P. Regasz-Rethy (RRethy) <rethy.spud@gmail.com>
 License: Same terms as Vim itself (see |license|)
 
+QUICKSTART                     |align-quickstart|
+COMMANDS                       |align-commands|
+EXAMPLES                       |align-examples|
+
 QUICKSTART                                                 *align-quickstart*
 ===========================================================================
-
 >
-    command! -range=% -nargs=1 Align lua require('align').align(<f-args>)
-
     " In visual mode
-    :'<,'>Align regex_pattern.*
+    :'<,'>Align regex_pattern
 <
-
-FUNCTIONS                                                   *align-functions*
+COMMANDS                                                     *align-commands*
 ===========================================================================
 
-Make sure to `local align = require('align')` .
+:|'<|,|'>|Align {pattern}                                                 *Align*
+        (In visual mode) Aligns {pattern} over the lines |'<|,|'>|. If
+	no range is specified, the most recently selected lines will
+	be aligned.
 
-align.align({pattern})                                          *align.align*
-        Aligns {pattern} over the lines |'<|,|'>|.
-
-align.align_lines({patter}, {startline}, {endline})       *align.align_lines*
+:AlignLines {pattern}, {startline}, {endline}                    *AlignLines*
         Aligns {pattern} from {startline} to {endline}. Indexing is
-        zero-indexed, end-exclusive.
+        zero-indexed, end-exclusive. Escape whitespace with backslash.
+
+EXAMPLES                                                     *align-examples*
+===========================================================================
+>
+	1  var x = 1
+	2  var xx = 2
+	3  var xxx = 3
+	4  var xxxx = 4
+	5  var xxxxx = 5
+	6  var xxxxxx = 6
+<
+" Basic visual-mode command; selecting all lines.
+:'<,'>Align =
+>
+	1  var x      = 1
+	2  var xx     = 2
+	3  var xxx    = 3
+	4  var xxxx   = 4
+	5  var xxxxx  = 5
+	6  var xxxxxx = 6
+<
+" With no range specified, Align will use the most recent selection.
+:Align x
+>
+	1  var      x      = 1
+	2  var x    x     = 2
+	3  var xx   x    = 3
+	4  var xxx  x   = 4
+	5  var xxxx x  = 5
+	6  var xxxxxx = 6
+<
+" Selecting a specific range. The regex matches "  =".
+:AlignLines \ \ = 2 5
+>
+	1  var      x      = 1
+	2  var x    x     = 2
+	3  var xx   x    = 3
+	4  var xxx  x    = 4
+	5  var xxxx x    = 5
+	6  var xxxxxx = 6
+<
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/lua/align.lua
+++ b/lua/align.lua
@@ -8,8 +8,12 @@ function M.align(pat)
 end
 
 function M.align_lines(pat, startline, endline)
-    local re = vim.regex(pat)
+ 	local startline = tonumber(startline)
+	local endline   = tonumber(endline)
+
+	local re = vim.regex(pat)
     local max = -1
+
     local lines = vim.api.nvim_buf_get_lines(0, startline, endline, false)
     for _, line in pairs(lines) do
         local s = re:match_str(line)

--- a/lua/align.lua
+++ b/lua/align.lua
@@ -9,7 +9,12 @@ end
 
 function M.align_lines(pat, startline, endline)
  	local startline = tonumber(startline)
-	local endline   = tonumber(endline)
+	local endline = tonumber(endline)
+
+	-- Convert to start-inclusive range
+	if startline > 0 then
+		startline = startline - 1
+	end
 
 	local re = vim.regex(pat)
     local max = -1

--- a/plugin/align.vim
+++ b/plugin/align.vim
@@ -1,0 +1,7 @@
+if exists('g:loaded_align_nvim')
+  finish
+endif
+
+command! -range=% -nargs=1 Align lua require'align'.align(<f-args>)
+
+let g:loaded_align_nvim = 1

--- a/plugin/align.vim
+++ b/plugin/align.vim
@@ -1,7 +1,6 @@
-if exists('g:loaded_align_nvim')
-  finish
+if !exists('g:loaded_align_nvim')
+	command! -range=% -nargs=1 Align lua require'align'.align(<f-args>)
+	command! -nargs=+ AlignLines lua require'align'.align_lines(<f-args>)
+	let g:loaded_align_nvim = 1
 endif
 
-command! -range=% -nargs=1 Align lua require'align'.align(<f-args>)
-
-let g:loaded_align_nvim = 1


### PR DESCRIPTION
This addition obviates the need to run `command! -range=% -nargs=1 Align lua require'align'.align(<f-args>)` separately. Instead, it runs automatically when the plugin is loaded.